### PR TITLE
chore: update attributes list documentation

### DIFF
--- a/R/00-s1ocn_the.R
+++ b/R/00-s1ocn_the.R
@@ -28,20 +28,11 @@ s1ocn_the$cache <- list(
 #'
 #' The attributes list includes the names of acceptable attributes for querying the Sentinel-1 dataset, along with their respective types.
 #'
-#' @examples
-#' \dontrun{
-#' # Retrieve the list of attributes for Sentinel-1
-#' attributes_list <- s1ocn_the$get_attributes_list()
-#'
-#' # View the list of attribute names and types
-#' print(attributes_list)
-#' }
-#'
 #' @importFrom curl curl
 #' @importFrom jsonlite fromJSON
 #' @importFrom rlang is_zap
-#' @title s1ocn_the$get_attributes_list
 #' @name get_attributes_list
+#' @keywords internal
 s1ocn_the$get_attributes_list <- function() {
 
   # Retrieve the cached attributes list from the object `s1ocn_the`

--- a/man/get_attributes_list.Rd
+++ b/man/get_attributes_list.Rd
@@ -2,20 +2,18 @@
 % Please edit documentation in R/00-s1ocn_the.R
 \name{get_attributes_list}
 \alias{get_attributes_list}
-\title{s1ocn_the$get_attributes_list}
+\title{Retrieve and Cache the List of Acceptable Attribute Names for Sentinel-1}
+\description{
+This function retrieves a list of acceptable attribute names and their types for the Copernicus Sentinel-1 Mission.
+The data is retrieved from the Copernicus Data Space Catalogue via an OData API. To improve performance, the results
+are cached after the first retrieval. Subsequent calls will return the cached list unless the cache is reset.
+}
 \value{
 A list of acceptable attribute names and their types for the Sentinel-1 mission, retrieved from the
 Copernicus Data Space Catalogue. If the data has already been retrieved during the session, the function returns
 the cached version to avoid unnecessary API calls.
 }
-\description{
-Retrieve and Cache the List of Acceptable Attribute Names for Sentinel-1
-}
 \details{
-This function retrieves a list of acceptable attribute names and their types for the Copernicus Sentinel-1 Mission.
-The data is retrieved from the Copernicus Data Space Catalogue via an OData API. To improve performance, the results
-are cached after the first retrieval. Subsequent calls will return the cached list unless the cache is reset.
-
 The function operates as follows:
 \enumerate{
 \item \strong{Cache Check:} The function first checks if the list of attributes is stored in the cache (\code{s1ocn_the$cache$attibutes_list}).
@@ -30,13 +28,4 @@ subsequent calls.
 
 The attributes list includes the names of acceptable attributes for querying the Sentinel-1 dataset, along with their respective types.
 }
-\examples{
-\dontrun{
-# Retrieve the list of attributes for Sentinel-1
-attributes_list <- s1ocn_the$get_attributes_list()
-
-# View the list of attribute names and types
-print(attributes_list)
-}
-
-}
+\keyword{internal}


### PR DESCRIPTION
## Summary
- clean up `get_attributes_list` documentation and mark internal
- refresh generated man page without examples

## Testing
- `RENV_CONFIG_AUTOLOADER_ENABLED=FALSE R -q -e "devtools::document()"` *(fails: there is no package called 'devtools')*
- `RENV_CONFIG_AUTOLOADER_ENABLED=FALSE R -q -e "testthat::test_dir('tests')"` *(fails: there is no package called 'testthat')*

------
https://chatgpt.com/codex/tasks/task_e_68a17f3bcae4832d99de51f80a4cd6eb